### PR TITLE
Address build warnings

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.23.4-alpine AS build-backend
 
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-ENV GOARCH amd64
-ENV GOOS windows
+ENV GOARCH=amd64
+ENV GOOS=windows
 
 COPY ./src /app
-RUN cd /app && go get -d \
+RUN cd /app && go mod download \
  && go build \
     -a \
     -ldflags '-s -w -extldflags "-static"' \
@@ -18,6 +18,6 @@ ENV LANG=C.UTF-8
 
 # we don't really need to run this image, but we add a CMD
 # to make it run more convenient
-CMD /npipe.exe
+CMD ["/npipe.exe"]
 
 COPY --from=build-backend /npipe.exe /npipe.exe

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.23.4-nanoserver AS build-backend
 
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-ENV GOARCH amd64
-ENV GOOS windows
+ENV GOARCH=amd64
+ENV GOOS=windows
 
 COPY ./src /app
-RUN cd /app && go get -d \
+RUN cd /app && go mod download \
  && go build \
     -a \
     -ldflags "-s -w -extldflags \"-static\"" \


### PR DESCRIPTION
- Legacy key/value format with whitespace separator should not be used: linux/Dockerfile#L3
  LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

- Legacy key/value format with whitespace separator should not be used: linux/Dockerfile#L5
  LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

- Legacy key/value format with whitespace separator should not be used: linux/Dockerfile#L6
  LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

- JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals: linux/Dockerfile#L21
  JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals
  More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/